### PR TITLE
plan and coach images dont repeat themselves anymore

### DIFF
--- a/app/views/plans/_planlist.html.erb
+++ b/app/views/plans/_planlist.html.erb
@@ -1,9 +1,9 @@
 <div class="container">
   <div class="custom-plans-container">
-    <% @plans.each do |plan| %>
+    <% @plans.each_with_index do |plan, index| %>
       <div class="card custom-card">
-        <!-- <%= image_tag "https://picsum.photos/1000/700", alt: "alttext", class: "custom-card-image"  %> -->
-        <%= image_tag "https://source.unsplash.com/collection/779536/1000x700", alt: "alttext", class: "custom-card-image"  %>
+        <% plan_pictures = ['plan_1_acxcun','plan_2_vwme0f','plan_3_hnu5n4','plan_4_pfdfwf','plan_5_rbvghf','plan_6_fgesi9','plan_7_yn7czo','plan_8_bowbl5','plan_9_cp9yf6','plan_10_yncibx','plan_11_tttsf7','plan12_bdstia'] %>
+        <%= cl_image_tag(plan_pictures[index], transformation: { dpr: "auto", responsive: true, width: "auto", height: 310, crop: "fit"}) %>
         <div class="card-body">
           <h5 class="card-title"><%= plan.name %></h5>
           <p class="card-text"><%=h truncate(plan.description, length: 200) %></p>

--- a/app/views/plans/show.html.erb
+++ b/app/views/plans/show.html.erb
@@ -9,7 +9,8 @@
   <hr>
   <ul>
     <div class="custom-coaches-container">
-      <% @coaches.each do |coach| %>
+      <% @coaches.each_with_index do |coach, index| %>
+        <% coach_pictures = [ 'coach_1_ijvlgq', 'coach_2_de5ci2', 'coach_3_lfommq', 'coach_4_wknahr', 'coach_5_hkjpgt', 'coach_6_jwit9j', 'coach_7_lr6pbi', 'coach_8_u8tuq7', 'coach_9_lldapq', 'coach_10_asltiy', 'coach_11_cekvcs', 'coach_12_j2bvso', 'coach_13_grpqwi', 'coach_14_ib9rhe', 'coach_15_qrquwu', 'coach_16_hmtdac'] %>
         <li>
           <div class="card custom-card">
             <div class="card-body">
@@ -17,7 +18,7 @@
               <% if coach.coach_record.profile_picture.attached? %>
                 <%= cl_image_tag coach.coach_record.profile_picture.key, alt: "Profile picture", class: "avatar-square dropdown-toggle m-1", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
               <% else %>
-                <%= image_tag "https://st2.depositphotos.com/4111759/12123/v/950/depositphotos_121232794-stock-illustration-male-default-placeholder-avatar-profile.jpg", class: "avatar-square dropdown-toggle m-1", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false %>
+                <%= cl_image_tag(coach_pictures[index] , class: "avatar-square dropdown-toggle m-1", id: "navbarDropdown", data: { toggle: "dropdown" }, 'aria-haspopup': true, 'aria-expanded': false ) %>
               <% end %>
               <p class="text-suc"><%= coach.coach_record.specialty %></p>
               <p><%=h truncate(coach.coach_record.description, length: 40) %></p>


### PR DESCRIPTION
**Why?**
Some issue with the browser and the unsplash API prevented us from showing different pictures per each seeded example


**How?**
Created a couple cloudinary collections so we could showcase different pictures, might benefit from some work or better picture selection but looks way better